### PR TITLE
Adhoc: Use the from set by prepare

### DIFF
--- a/src/Moxl/Xec/Action/AdHoc/Command.php
+++ b/src/Moxl/Xec/Action/AdHoc/Command.php
@@ -30,7 +30,7 @@ class Command extends Action
 
     public function handle($stanza, $parent = false) {
         $this->prepare($stanza, $parent);
-        $this->pack($stanza->command, $stanza->from);
+        $this->pack($stanza->command);
         $this->deliver();
     }
 


### PR DESCRIPTION
Missed this when I submitted my last AdHoc PR. Should only set
from once: in prepare. Not override it with an (incorrect) string right
after.